### PR TITLE
fixed accessing static var in non static context

### DIFF
--- a/vero.php
+++ b/vero.php
@@ -8,7 +8,7 @@
 
   class Vero {
 
-    private static $client;
+    private $client;
 
     public function __construct($auth_token, $development_mode = false) {
       if (!$auth_token)

--- a/vero/client.php
+++ b/vero/client.php
@@ -4,8 +4,8 @@
 
   class Client {
 
-    private static $auth_token;
-    private static $development_mode;
+    private $auth_token;
+    private $development_mode;
 
     public function __construct($auth_token, $development_mode = false) {
       $this->auth_token = $auth_token;


### PR DESCRIPTION
Fixed the error, where the class was trying to access static variables in non static context.
