### PR TITLE
more compatible

### DIFF
--- a/vero.php
+++ b/vero.php
@@ -4,7 +4,7 @@
     throw new Exception('Vero needs the JSON PHP extension.');
   }
 
-  require('./vero/client.php');
+  require(dirname(__FILE__) . '/vero/client.php');
 
   class Vero {
 


### PR DESCRIPTION
the change can avoid the failure of loading library file. Image there is index.php file which load the library siting in different folder from the library vero-php, like the follow structure:
- index.php
- library
     - vero-php
        - vero
           - client.php
        - vero.php

Index.php can't load the file using relative path as require('./vero/client.php'). A more way proper way would be require(dirname(__FILE__) . '/vero/client.php').