### PR TITLE
Add API client request for Heart Beat

### DIFF
--- a/vero.php
+++ b/vero.php
@@ -74,6 +74,10 @@
       return $this->client->track($event_name, $identity, $data, $extras);
     }
 
+    public function heartbeat() {
+        return $this->client->heartbeat();
+    }
+
   }
 
 ?>

--- a/vero/client.php
+++ b/vero/client.php
@@ -91,6 +91,12 @@
       return $this->_send($endpoint, $request_data);
     }
 
+    public function heartbeat() {
+        $endpoint = "https://api.getvero.com/api/v2/heartbeat";
+        $request_data=array();
+        return $this->_send($endpoint, $request_data, 'get');
+    }
+
     private function _send($endpoint, $request_data, $request_type = 'post') {
       $request_data = json_encode($request_data);
 
@@ -106,8 +112,12 @@
         curl_setopt($handle, CURLOPT_POST, true);
       } elseif ($request_type == 'put') {
         curl_setopt($handle, CURLOPT_CUSTOMREQUEST, "PUT");
+      } else if ($request_type == 'get') {
+      	curl_setopt($handle, CURLOPT_CUSTOMREQUEST, 'GET');
       }
-      curl_setopt($handle, CURLOPT_POSTFIELDS, $request_data);
+      if($request_type == 'post' || $request_type == 'put') {
+        curl_setopt($handle, CURLOPT_POSTFIELDS, $request_data);
+      }
 
       $result = curl_exec($handle);
       $code   = curl_getinfo($handle, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Add client API heart beat request, because the call requires a GET Method minor modifications to _send function was required namely updates to the curl call.
